### PR TITLE
Bugs with math calculations, numbers not strings

### DIFF
--- a/dist/js/swiper.js
+++ b/dist/js/swiper.js
@@ -1438,7 +1438,14 @@
         slidePosition = slidePosition + slideSize + spaceBetween;
       }
 
-      swiper.virtualSize += slideSize + spaceBetween;
+      try {
+        // For some reason the Javascript engine I was using was concatenating strings instead of adding numbers.
+        swiper.virtualSize = parseInt(swiper.virtualSize,10);
+        swiper.virtualSize += (parseInt(slideSize, 10) + (parseInt(spaceBetween, 10)));
+      } catch (err) {
+        // This is the code that was concatenating strings instead of adding numbers.
+        swiper.virtualSize += slideSize + spaceBetween;
+      }
 
       prevSlideSize = slideSize;
 
@@ -3343,7 +3350,8 @@
       });
 
       swiper.currentBreakpoint = breakpoint;
-
+      var default_slidesPerView = params.slidesPerView; //Do we need this?
+      swiper.params.slidesPerView = breakPointsParams.slidesPerView; // Use the breakpoint slidesPerView.
       if (needsReLoop && initialized) {
         swiper.loopDestroy();
         swiper.loopCreate();


### PR DESCRIPTION
See related issue:
https://github.com/nolimits4web/swiper/issues/2789

Breakpoints logic fix for responsiveness, related code was concatenating strings instead of adding numbers.  Force integer with parseInt.  Also make sure that slidesPerView is using the breakpoints current value.  Something still isn't right though but this is worth discussing and I think part of this merge request should be taken in.